### PR TITLE
remove the  unused max and min feature size from the DBs

### DIFF
--- a/simstring/database/base.py
+++ b/simstring/database/base.py
@@ -5,11 +5,5 @@ class BaseDatabase:
     def add(self, string):
         raise NotImplementedError
 
-    def min_feature_size(self):
-        raise NotImplementedError
-
-    def max_feature_size(self):
-        raise NotImplementedError
-
     def lookup_strings_by_feature_set_size_and_feature(self, size, feature):
         raise NotImplementedError

--- a/simstring/database/dict.py
+++ b/simstring/database/dict.py
@@ -39,9 +39,6 @@ class DictDatabase(BaseDatabase):
 
         self.feature_set_size_to_string_map[size].add(string)
 
-        self._min_feature_size = min(self._min_feature_size, size)
-        self._max_feature_size = max(self._max_feature_size, size)
-
         for feature in features:
             self.feature_set_size_and_feature_to_string_map[size][feature].add(string)
 
@@ -52,12 +49,6 @@ class DictDatabase(BaseDatabase):
         self, size: int, feature: str
     ) -> Set[str]:
         return self.feature_set_size_and_feature_to_string_map[size][feature]
-
-    def min_feature_size(self) -> int:
-        return self._min_feature_size
-
-    def max_feature_size(self) -> int:
-        return self._max_feature_size
 
     def to_pickle(self, f: BufferedWriter) -> None:
         """Hack to get object savable with mypyc

--- a/simstring/database/disk.py
+++ b/simstring/database/disk.py
@@ -27,8 +27,6 @@ class DiskDatabase(BaseDatabase):
         self.feature_extractor = feature_extractor
         self.feature_set_size_to_string_map: dc.Cache = dc.Cache(os.path.join(path,'feature_set_size_to_string_map'))
         self.feature_set_size_and_feature_to_string_map: dc.Cache = dc.Cache(os.path.join(path,'feature_set_size_and_feature_to_string_map'))
-        self._min_feature_size = 9999999
-        self._max_feature_size = 0
         self.path = path
 
     @staticmethod
@@ -59,9 +57,6 @@ class DiskDatabase(BaseDatabase):
         features = self.feature_extractor.features(string)
 
         size = len(features)
-        self._min_feature_size = min(self._min_feature_size, size)
-        self._max_feature_size = max(self._max_feature_size, size)
-
         with self.feature_set_size_to_string_map.transact():  
             if size not in self.feature_set_size_to_string_map:
                 size_to_string_map = set()
@@ -84,12 +79,3 @@ class DiskDatabase(BaseDatabase):
         self, size: int, feature: str
     ) -> Set[str]:
         return self.get_feature_set_size_and_feature_to_string_map(size,feature)
-
-    def min_feature_size(self) -> int:
-        return self._min_feature_size
-
-    def max_feature_size(self) -> int:
-        return self._max_feature_size
-
-
-

--- a/tests/database/test_dbs.py
+++ b/tests/database/test_dbs.py
@@ -34,11 +34,6 @@ class TestComparability(TestCase):
     def test_strings(self):
         self.assertEqual(set(self.dict_db.all()), set(self.disk_db.all()))
 
-    def test_min_feature_size(self):
-        self.assertEqual(self.dict_db.min_feature_size(), self.disk_db.min_feature_size())
-
-    def test_max_feature_size(self):
-        self.assertEqual(self.dict_db.max_feature_size(), self.disk_db.max_feature_size())
 
     def test_equivalence_disk_to_dict(self):
         for key in self.disk_db.feature_set_size_to_string_map.iterkeys():

--- a/tests/database/test_dict.py
+++ b/tests/database/test_dict.py
@@ -19,12 +19,6 @@ class TestDict(TestCase):
         self.assertEqual(sorted(self.db.all()), sorted(self.strings))
 
 
-    def test_min_feature_size(self):
-        self.assertEqual(self.db.min_feature_size(), 2)
-
-    def test_max_feature_size(self):
-        self.assertEqual(self.db.max_feature_size(), 6)
-
     def test_lookup_strings_by_feature_set_size_and_feature(self):
         self.assertEqual(
             self.db.lookup_strings_by_feature_set_size_and_feature(4, "ab_1"),

--- a/tests/database/test_disk.py
+++ b/tests/database/test_disk.py
@@ -24,11 +24,6 @@ class TestDisk(TestCase):
     def test_strings(self):
         self.assertEqual(sorted(self.db.all()), sorted(self.strings))
 
-    def test_min_feature_size(self):
-        self.assertEqual(self.db.min_feature_size(), 2)
-
-    def test_max_feature_size(self):
-        self.assertEqual(self.db.max_feature_size(), 6)
 
     def test_lookup_strings_by_feature_set_size_and_feature(self):
         self.assertEqual(
@@ -52,8 +47,6 @@ class TestDisk(TestCase):
         with open("test.pkl", "rb") as f:
             new =  pickle.load(f)
 
-        self.assertEqual(self.db._min_feature_size, new._min_feature_size)
-        self.assertEqual(self.db._max_feature_size, new._max_feature_size)
         self.assertEqual(
             self.db.feature_extractor.__class__, new.feature_extractor.__class__
         )


### PR DESCRIPTION
just removes an unused feature and simplifies the add parallelisation